### PR TITLE
Fix parsing verify respons

### DIFF
--- a/src/hooks/yodl.ts
+++ b/src/hooks/yodl.ts
@@ -1,4 +1,9 @@
-import { PaymentDetails, TxDetails, VerifiedTxDetails } from "../types";
+import {
+  PaymentDetails,
+  TxDetails,
+  VerifiedTxDetails,
+  VerifyResponse,
+} from "../types";
 import { useEffect, useState } from "react";
 import { MAX_FETCH_TX_ATTEMPTS, TX_FETCH_INTERVAL } from "../constants";
 import { sleep } from "../helpers";
@@ -59,9 +64,9 @@ export const useVerify = (
           return;
         }
 
-        const verifiedTxDetails = (await res.json()) as VerifiedTxDetails[];
+        const verifyResponse = (await res.json()) as VerifyResponse;
         const { verified, verificationErrors, ...txDetails } =
-          verifiedTxDetails[0];
+          verifyResponse.payments[0];
         setIsVerified(verified);
         setTxDetails(txDetails);
         setIsLoading(false);

--- a/src/hooks/yodl.ts
+++ b/src/hooks/yodl.ts
@@ -1,9 +1,4 @@
-import {
-  PaymentDetails,
-  TxDetails,
-  VerifiedTxDetails,
-  VerifyResponse,
-} from "../types";
+import { PaymentDetails, TxDetails, VerifyResponse } from "../types";
 import { useEffect, useState } from "react";
 import { MAX_FETCH_TX_ATTEMPTS, TX_FETCH_INTERVAL } from "../constants";
 import { sleep } from "../helpers";

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,12 @@ export type VerifiedTxDetails = TxDetails & {
   verificationErrors: string[];
 };
 
+export type VerifyResponse = {
+  chainId: number;
+  txHash: string;
+  payments: VerifiedTxDetails[];
+};
+
 export type PaymentDetails = {
   memo: string;
   amount: number;


### PR DESCRIPTION
The `\verify` response was changed along with the URL, so we need to update the type of the response and handle it.